### PR TITLE
fix(): Create tun dev if not present

### DIFF
--- a/client/scripts/waitForConfigToRunCmd.sh
+++ b/client/scripts/waitForConfigToRunCmd.sh
@@ -31,6 +31,12 @@ do
       timer=$((timer-1))
 done
 
+echo "File $configFile Found. Creating tun device"
+mkdir -p /dev/net
+if [ ! -c /dev/net/tun ]; then
+    mknod /dev/net/tun c 10 200
+fi
+
 # Exec the openvpn command so that ctrl-c will work when running from terminal
 echo "File $configFile Found. Running"
 exec "$@"


### PR DESCRIPTION
Create the tun device in /dev/net before the openvpn proc starts.

Signed-off-by: Bharath Horatti <bharath@aveshasystems.com>